### PR TITLE
bugfix: fix custom tool schema overriding

### DIFF
--- a/src/agentpool/agents/native_agent/agent.py
+++ b/src/agentpool/agents/native_agent/agent.py
@@ -662,9 +662,9 @@ class Agent[TDeps = None, OutputDataT = str](BaseAgent[TDeps, OutputDataT]):
                 prepare_fn = create_prepare(tool)
 
             if get_argument_key(wrapped, RunContext):
-                agent.tool(wrapped, prepare=prepare_fn)  # type: ignore
+                agent.tool(wrapped, prepare=prepare_fn)
             else:
-                agent.tool_plain(wrapped, prepare=prepare_fn)  # type: ignore
+                agent.tool_plain(wrapped, prepare=prepare_fn)
         return agent  # type: ignore[return-value]
 
     async def _process_node_stream(

--- a/tests/test_schema_override.py
+++ b/tests/test_schema_override.py
@@ -1,8 +1,11 @@
 from pydantic_ai.tools import ToolDefinition
+from typing import Any
 import pytest
-
 from agentpool.agents.native_agent.agent import Agent
 from agentpool.tools.base import Tool
+from pydantic_ai import Agent as PydanticAgent
+from pydantic_ai.tools import ToolDefinition
+from schemez import OpenAIFunctionDefinition
 
 
 def my_tool(arg1: str):
@@ -14,7 +17,7 @@ def my_tool(arg1: str):
 async def test_schema_override_propagation():
     """Test that schema overrides are propagated to the PydanticAI agent via prepare."""
     # Define a schema override
-    override = {
+    override: OpenAIFunctionDefinition = {
         "name": "my_tool",
         "description": "Overridden description",
         "parameters": {
@@ -30,7 +33,7 @@ async def test_schema_override_propagation():
 
     agent = Agent(name="test-agent", model="openai:gpt-4o", tools=[tool])
 
-    pydantic_agent = await agent.get_agentlet(None, None)
+    pydantic_agent: PydanticAgent[Any, Any] = await agent.get_agentlet(None, None)
 
     found_tool_def = None
 
@@ -38,11 +41,11 @@ async def test_schema_override_propagation():
     # Note: This relies on pydantic-ai internals, which might change.
     # But it's the only way to inspect without running the agent against an LLM.
 
-    toolsets = []
+    toolsets: list[Any] = []
     if hasattr(pydantic_agent, "_function_toolset"):
         toolsets.append(pydantic_agent._function_toolset)
     if hasattr(pydantic_agent, "_user_toolsets"):
-        toolsets.extend(pydantic_agent._user_toolsets)
+        toolsets.extend(pydantic_agent._user_toolsets)  # type: ignore
 
     for ts in toolsets:
         tools = getattr(ts, "tools", {})


### PR DESCRIPTION
# Summary
This PR fixes a bug where schema_override properties (such as custom names, descriptions, or parameters) defined in Tool objects were being ignored by the Native Agent when initializing the underlying PydanticAI agent.
# Problem
When a Tool was created with a schema_override, the native agent's get_agentlet method would wrap the tool but fail to pass these overrides to the PydanticAI backend. As a result, the LLM would see the original function signature and docstring instead of the intended overridden schema.
# Solution
I updated src/agentpool/agents/native_agent/agent.py to use the prepare callback mechanism provided by pydantic-ai.
- When registering a tool, we now check for schema_override.
- If present, a prepare function is injected which dynamically constructs a ToolDefinition with the overridden name, description, and parameters_json_schema at runtime.
# Testing
- Added a new regression test tests/test_schema_override.py which mocks the tool preparation context and verifies that the ToolDefinition correctly reflects the overridden values.
- Verified that existing functionality remains unaffected.
Closes #14